### PR TITLE
install suggested dependencies before dependencies

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -6,7 +6,7 @@ runs:
   steps: 
     - name: Install package dependencies 📄
       run: |
-        pak::local_install_deps(".", upgrade=FALSE, ask=FALSE)
+        pak::local_install_deps(".", upgrade=FALSE, ask=FALSE, dependencies = TRUE)
       shell: Rscript {0}
 
 


### PR DESCRIPTION
See for example:

```
❯ checking package dependencies ... ERROR
  Package suggested but not available: ‘dv.loader’
  
  The suggested packages are required for a complete check.
  Checking can be attempted without them by setting the environment
  variable _R_CHECK_FORCE_SUGGESTS_ to a false value.
```