### PR TITLE
include qc report in a separate step

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
+        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
 
       - name: Check 📦
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,27 +16,29 @@ on:
   workflow_call:
 
 concurrency:
-  group: check-test-${{ github.event.pull_request.number || github.ref }}
+  group: check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check-test:
+  check:
     name: ${{ vars.CI_IMAGE }}
     runs-on: ubuntu-latest
     container:
       image: ${{ vars.CI_IMAGE }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout project ⬇️
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
+        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
 
       - name: Check 📦
         run: |
           options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(error_on = "error")
+          rcmdcheck::rcmdcheck(error_on = "error", args = "--no-tests")
         shell: Rscript {0}
 
 

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -39,11 +39,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
+        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
 
       - name: Import .lintr
         run: |
-          wget -O .lintr https://raw.githubusercontent.com/zsigmas/dv.templates/main/.lintr
+          wget -O .lintr https://raw.githubusercontent.com/boehringer-ingelheim/dv.templates/main/.lintr
 
       - name: Lintr 🔍
         run: lintr::lint_package()

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps        
+        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main        
         
       - name: Get validation results
         uses: actions/download-artifact@v4

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -25,13 +25,21 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ vars.CI_IMAGE }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout project ⬇️
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main           
+        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps        
+        
+      - name: Get validation results
+        uses: actions/download-artifact@v4
+        with:
+          name: val_results
+          path: inst/validation/results
 
       - name: Build site 🔧
         run: pkgdown::build_site()

--- a/.github/workflows/roxygen.yml
+++ b/.github/workflows/roxygen.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
+        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
 
       - name: Generate man pages 📄
         run: |

--- a/.github/workflows/roxygen.yml
+++ b/.github/workflows/roxygen.yml
@@ -25,13 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ vars.CI_IMAGE }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout project ⬇️
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
+        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
 
       - name: Generate man pages 📄
         run: |

--- a/.github/workflows/shared_ci.yml
+++ b/.github/workflows/shared_ci.yml
@@ -7,31 +7,31 @@ on:
 jobs:
   check:
     name: Check 📦
-    uses: zsigmas/dv.templates/.github/workflows/check.yml@include_qc_separate_steps
+    uses: boehringer-ingelheim/dv.templates/.github/workflows/check.yml@main
 
   test:
     name: Test 📦
-    uses: zsigmas/dv.templates/.github/workflows/test.yml@include_qc_separate_steps
+    uses: boehringer-ingelheim/dv.templates/.github/workflows/test.yml@main
 
   lintr:
     name: Lintr 🔍
-    uses: zsigmas/dv.templates/.github/workflows/lintr.yml@include_qc_separate_steps
+    uses: boehringer-ingelheim/dv.templates/.github/workflows/lintr.yml@main
     with:
       lintr_error_on_lint: true
 
   gitleaks:
     name: Gitleaks 🌧️
-    uses: zsigmas/dv.templates/.github/workflows/gitleaks.yml@include_qc_separate_steps
+    uses: boehringer-ingelheim/dv.templates/.github/workflows/gitleaks.yml@main
 
   roxygen:
     name: Roxygen 📄
-    uses: zsigmas/dv.templates/.github/workflows/roxygen.yml@include_qc_separate_steps
+    uses: boehringer-ingelheim/dv.templates/.github/workflows/roxygen.yml@main
 
   pkgdown:
     name: Pkgdown 📖
-    uses: zsigmas/dv.templates/.github/workflows/pkgdown.yml@include_qc_separate_steps
+    uses: boehringer-ingelheim/dv.templates/.github/workflows/pkgdown.yml@main
     needs: test
 
   styler:
     name: Styler 🌐
-    uses: zsigmas/dv.templates/.github/workflows/styler.yml@include_qc_separate_steps
+    uses: boehringer-ingelheim/dv.templates/.github/workflows/styler.yml@main

--- a/.github/workflows/shared_ci.yml
+++ b/.github/workflows/shared_ci.yml
@@ -5,28 +5,33 @@ on:
   workflow_call:
 
 jobs:
-  check-test:
+  check:
     name: Check 📦
-    uses: boehringer-ingelheim/dv.templates/.github/workflows/check.yml@main
+    uses: zsigmas/dv.templates/.github/workflows/check.yml@include_qc_separate_steps
+
+  test:
+    name: Test 📦
+    uses: zsigmas/dv.templates/.github/workflows/test.yml@include_qc_separate_steps
 
   lintr:
     name: Lintr 🔍
-    uses: boehringer-ingelheim/dv.templates/.github/workflows/lintr.yml@main
+    uses: zsigmas/dv.templates/.github/workflows/lintr.yml@include_qc_separate_steps
     with:
       lintr_error_on_lint: true
 
   gitleaks:
     name: Gitleaks 🌧️
-    uses: boehringer-ingelheim/dv.templates/.github/workflows/gitleaks.yml@main
+    uses: zsigmas/dv.templates/.github/workflows/gitleaks.yml@include_qc_separate_steps
 
   roxygen:
     name: Roxygen 📄
-    uses: boehringer-ingelheim/dv.templates/.github/workflows/roxygen.yml@main
+    uses: zsigmas/dv.templates/.github/workflows/roxygen.yml@include_qc_separate_steps
 
   pkgdown:
     name: Pkgdown 📖
-    uses: boehringer-ingelheim/dv.templates/.github/workflows/pkgdown.yml@main
+    uses: zsigmas/dv.templates/.github/workflows/pkgdown.yml@include_qc_separate_steps
+    needs: test
 
   styler:
     name: Styler 🌐
-    uses: boehringer-ingelheim/dv.templates/.github/workflows/styler.yml@main
+    uses: zsigmas/dv.templates/.github/workflows/styler.yml@include_qc_separate_steps

--- a/.github/workflows/styler.yml
+++ b/.github/workflows/styler.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
+        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
 
       - name: Run styler 🦄
         run: |

--- a/.github/workflows/styler.yml
+++ b/.github/workflows/styler.yml
@@ -25,13 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ vars.CI_IMAGE }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout project ⬇️
         uses: actions/checkout@v4
 
       - name: Install package dependencies 📄
-        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
+        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
 
       - name: Run styler 🦄
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: Lintr 🔍
+name: Test 📦
 
 on:
   pull_request:
@@ -14,19 +14,13 @@ on:
     branches:
       - main
   workflow_call:
-    inputs:
-      lintr_error_on_lint:
-        description: Raise lintr error when lints found.
-        required: false
-        default: true
-        type: boolean
 
 concurrency:
-  group: lint-${{ github.event.pull_request.number || github.ref }}
+  group: test-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  lintr:
+  test:
     name: ${{ vars.CI_IMAGE }}
     runs-on: ubuntu-latest
     container:
@@ -38,15 +32,21 @@ jobs:
       - name: Checkout project ⬇️
         uses: actions/checkout@v4
 
+      - name: Checkout Repo Templates      
+        uses: actions/checkout@v4
+        with:
+          ref: include_qc_separate_steps
+          repository: zsigmas/dv.templates
+          path: templates
+
       - name: Install package dependencies 📄
         uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
 
-      - name: Import .lintr
-        run: |
-          wget -O .lintr https://raw.githubusercontent.com/zsigmas/dv.templates/main/.lintr
+      - name: Test 📦
+        run: Rscript templates/scripts/test.R
 
-      - name: Lintr 🔍
-        run: lintr::lint_package()
-        shell: Rscript {0}
-        env:
-          LINTR_ERROR_ON_LINT: ${{ inputs.lintr_error_on_lint }}
+      - name: Archive validation results
+        uses: actions/upload-artifact@v4
+        with:
+          name: val_results
+          path: inst/validation/results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,11 +36,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: include_qc_separate_steps
-          repository: zsigmas/dv.templates
+          repository: boehringer-ingelheim/dv.templates
           path: templates
 
       - name: Install package dependencies 📄
-        uses: zsigmas/dv.templates/.github/actions/dependencies@include_qc_separate_steps     
+        uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     
 
       - name: Test 📦
         run: Rscript templates/scripts/test.R

--- a/scripts/test.R
+++ b/scripts/test.R
@@ -1,0 +1,126 @@
+#! /usr/local/bin/Rscript
+
+success <- c(
+  test = FALSE,
+  valdoc = FALSE
+)
+
+# Getting package information ----
+pkg_name <- read.dcf("DESCRIPTION")[1, "Package"]
+pkg_version <- read.dcf("DESCRIPTION")[1, "Version"]
+
+# Building ----
+
+message("############################")
+message("###### INSTALLING (S) ######")
+message("############################")
+
+devtools::install(upgrade = FALSE, args = "--install-tests")
+
+message("############################")
+message("###### INSTALLING (F) ######")
+message("############################")
+
+# Testing ----
+
+message("##########################")
+message("###### TESTING  (S) ######")
+message("##########################")
+
+reporter <- testthat::MultiReporter$new(
+  list(
+    testthat::ProgressReporter$new(),
+    testthat::SummaryReporter$new(file = file.path(getwd(), "tests", "test-out.xml"))
+  )
+)
+
+test_results <- tibble::as_tibble(
+  withr::with_envvar(
+    new = list(CI = TRUE, no_proxy = "127.0.0.1", NOT_CRAN = TRUE, TESTTHAT_CPUS = 1),
+    code = {
+      testthat::test_package(pkg_name, reporter, stop_on_failure = FALSE)
+    }
+  )
+)
+
+success[["test"]] <- sum(test_results[["failed"]]) == 0
+
+message("##########################")
+message("###### TESTING  (F) ######")
+message("##########################")
+
+# Validation ----
+
+message("#######################################")
+message("###### RENDERING VALIDATION  (S) ######")
+message("#######################################")
+
+success[["valdoc"]] <- local({
+  # This is evaluated inside a local because, otherwise, all the variables created in the chunks of the rendered
+  # document leak into the environment
+
+  validation_root <- "./inst/validation"
+  validation_report_rmd <- file.path(validation_root, "val_report.Rmd")
+  validation_report_html <- "val_report.html"
+  validation_results <- file.path(validation_root, "results")
+  val_param_rds <- file.path(validation_results, "val_param.rds")
+
+  stopifnot(dir.exists(validation_root))
+  stopifnot(file.exists(validation_report_rmd))
+
+  stopifnot(dir.exists(validation_results))
+  unlink(list.files(validation_results))
+
+  saveRDS(
+    list(
+      package = pkg_name,
+      tests = test_results,
+      version = pkg_version
+    ),
+    val_param_rds
+  )
+
+  rmarkdown::render(
+    input = validation_report_rmd,
+    params = list(
+      package = pkg_name,
+      tests = test_results,
+      version = pkg_version
+    ),
+    output_dir = validation_results,
+    output_file = validation_report_html
+  )
+
+  # We use one of the leaked variables, created inside the validation report to asses if the validation is succesful or not
+  VALIDATION_PASSED
+})
+
+
+message("#######################################")
+message("###### RENDERING VALIDATION  (F) ######")
+message("#######################################")
+
+# Exit ----
+message("##############################")
+message("###### BUILD RESULT (S) ######")
+message("##############################")
+
+message(paste("Was", names(success), "successful?\t", success, collapse = "\n"))
+
+# Write GITHUB ACTIONS summary
+github_summary_file <- Sys.getenv("GITHUB_STEP_SUMMARY")
+summary <- "# Test Summary"
+summary <- c(
+  summary,
+  purrr::imap_chr(success, ~ paste(" - ", if (.x) "\U02705" else "\U274C", "\t", .y))
+)
+
+CON <- file(github_summary_file, "a")
+on.exit(close(CON))
+writeLines(summary, CON)
+
+stopifnot(all(success))
+
+message("##############################")
+message("###### BUILD RESULT (F) ######")
+message("##############################")


### PR DESCRIPTION
I have created an alternative workflow where test and qc happen in separate steps.

The workflow runs all the steps as before with the following differences:
- Check does no longer run the tests
- test step also creates the validation report. This report is uploaded as an artifact in the test step.
- pkgdown step waits for the tests to run, then it downloads the test report artifact and creates the documentation.

This PR does not address including the qc in the templates repo instead of the package repo. A different PR can be done for that issue.

- Do not mind the repo and branch names in the workflow when ready to merge I will fix them.
