### PR TITLE
Feat/exclude qc from articles

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -100,6 +100,7 @@ jobs:
           render_site <- function(){
             if(file.exists('vignettes/qc.Rmd')){
               pkgdown::init_site()
+              devtools::install() # mimic the local installation that pkgdown::build_site does but pkgdown::build_article does not
               pkgdown::build_article(name = 'qc')
               file.rename(from = 'vignettes/qc.Rmd', to = 'vignettes/_qc.Rmd')
               # This last step is not necessary now but, if we ever want to combine actions,
@@ -107,7 +108,7 @@ jobs:
               # This block is written as a function to be able to lean on `on.exit`, btw.
               on.exit(file.rename(from = 'vignettes/_qc.Rmd', to = 'vignettes/qc.Rmd'))
             }
-            pkgdown::build_site(new_process = FALSE) # `new_process` because otherwise errors go unlogged
+            pkgdown::build_site(new_process = FALSE, install = FALSE) # `new_process` because otherwise errors go unlogged
           }
           render_site()
         shell: Rscript {0}

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -81,12 +81,13 @@ jobs:
           name: val_results
           path: inst/validation/results
 
-      - name: Build site 🔧
+      - name: Build site
         run: |
           # Pay the hadley tax: https://github.com/r-lib/roxygen2/issues/905
           desc <- read.dcf("DESCRIPTION")
           desc <- desc[, setdiff(colnames(desc), "RoxygenNote"), drop=FALSE]
           write.dcf(x = desc, file = "DESCRIPTION")
+
           # Generate docs
           rox_messages <- capture.output(roxygen2::roxygenize(clean = TRUE), type = "message")
           message(paste(rox_messages, collapse = '\n'))
@@ -94,8 +95,21 @@ jobs:
           if(any(error_mask)) {
             stop(paste("Errors while rendering roxygen documentation:", paste(rox_messages[error_mask], collapse = "\n")))
           }
+
           # Render site
-          pkgdown::build_site(new_process = FALSE) # otherwise errors are not logged
+          render_site <- function(){
+            if(file.exists('vignettes/qc.Rmd')){
+              pkgdown::init_site()
+              pkgdown::build_article(name = 'qc')
+              file.rename(from = 'vignettes/qc.Rmd', to = 'vignettes/_qc.Rmd')
+              # This last step is not necessary now but, if we ever want to combine actions,
+              # it's better to restore the original name of the file.
+              # This block is written as a function to be able to lean on `on.exit`, btw.
+              on.exit(file.rename(from = 'vignettes/_qc.Rmd', to = 'vignettes/qc.Rmd'))
+            }
+            pkgdown::build_site(new_process = FALSE) # `new_process` because otherwise errors go unlogged
+          }
+          render_site()
         shell: Rscript {0}
 
       - name: Check URLs 🌐

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -107,8 +107,10 @@ jobs:
               # it's better to restore the original name of the file.
               # This block is written as a function to be able to lean on `on.exit`, btw.
               on.exit(file.rename(from = 'vignettes/_qc.Rmd', to = 'vignettes/qc.Rmd'))
+              pkgdown::build_site(new_process = FALSE, install = FALSE) # `new_process` because otherwise errors go unlogged
+            } else {
+              pkgdown::build_site(new_process = FALSE) # `new_process` because otherwise errors go unlogged
             }
-            pkgdown::build_site(new_process = FALSE, install = FALSE) # `new_process` because otherwise errors go unlogged
           }
           render_site()
         shell: Rscript {0}


### PR DESCRIPTION
**(DONT REVIEW / APPROVE / MERGE THIS THING UNTIL FURTHER NOTICE)**

Running `pkgdown::build_site()` twice does the trick but it would potentially be slow for packages with a long reference.
That's why we run `pkgdown::init()` + `pkgdown::build_article('qc')`.

Sadly, building that article requires that the package is installed because of a `system.file()` call inside of `val_report_child.Rmd`.

_Sadlier_, there is no way of telling `pkgdown` to do a dummy package installation through `pkgdown::build_article(...)`, so we go ahead and just do a regular `devtools::install()` of the package.

_Sadliest_, since each rendered page has its own independent header, when you visit the Changelog section, the dropdown _still_ includes the offending QC link because the file was there at the time of rendering:
![image](https://github.com/user-attachments/assets/fdaccb46-f15b-412b-b8fc-8ff554ce6ec5)

I'm still doubting I should PR these changes...