### PR TITLE
Exclude institutional github blobs from lychee URL checking

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -119,9 +119,9 @@ jobs:
           done
         shell: bash
 
-      - name: Check URLs 🌐
+      - name: Check URLs
         run: |
-          lychee . --format markdown --verbose --no-progress --exclude "https://boehringer-ingelheim.github.io*" >> $GITHUB_STEP_SUMMARY
+          lychee . --format markdown --verbose --no-progress --exclude "https://boehringer-ingelheim\.github\.io.*" --exclude "https://github\.com/Boehringer-Ingelheim/.*/blob/.*" >> $GITHUB_STEP_SUMMARY
         shell: bash
 
       - name: Checkout gh-pages branch ⬇️

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Check URLs
         run: |
-          lychee . --format markdown --verbose --no-progress --exclude "https://boehringer-ingelheim\.github\.io.*" --exclude "https://github\.com/Boehringer-Ingelheim/.*/blob/.*" >> $GITHUB_STEP_SUMMARY
+          lychee . --format markdown --verbose --no-progress --exclude "https://boehringer-ingelheim\.github\.io.*" --exclude "https://github\.com/boehringer-ingelheim/.*/blob/.*" >> $GITHUB_STEP_SUMMARY
         shell: bash
 
       - name: Checkout gh-pages branch ⬇️


### PR DESCRIPTION
We already exclude all links to `boehringer-ingelheim.github.io/<whatever>`. Maybe we don't need to check links to `github.com/boehringer-ingelheim/<whatever>/blob/<whatever>"` either.