### PR TITLE
Accept both capitalizations of lychee exclusion pattern

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Check URLs
         run: |
-          lychee . --format markdown --verbose --no-progress --exclude "https://boehringer-ingelheim\.github\.io.*" --exclude "https://github\.com/boehringer-ingelheim/.*/blob/.*" >> $GITHUB_STEP_SUMMARY
+          lychee . --format markdown --verbose --no-progress --exclude "https://[Bb]oehringer-[Ii]ngelheim\.github\.io.*" --exclude "https://github\.com/[Bb]oehringer-[Ii]ngelheim/.*/blob/.*" >> $GITHUB_STEP_SUMMARY
         shell: bash
 
       - name: Checkout gh-pages branch ⬇️


### PR DESCRIPTION
Github accepts both "Boehringer-Ingelheim" and "boehringer-ingelheim" in URLs. This PR excludes both patterns.