### PR TITLE
updates to recent actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout project ⬇️
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
 
       - name: Install package dependencies 📄
         uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout project ⬇️
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
 
       - name: Install package dependencies 📄
         uses: boehringer-ingelheim/dv.templates/.github/actions/dependencies@main     

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout project ⬇️
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
 
       - name: Checkout templates repo ⬇️  
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
         with:
           ref: ${{env.TEMPLATE_REF}}
           repository: ${{env.TEMPLATE_REPO}}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Checkout gh-pages branch ⬇️
         if: github.ref_name == 'main'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
         with:
           path: gh-pages
           ref: gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
 
       - name: NEWS.md and DESCRIPTION version check
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout project ⬇️
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
 
       - name: Checkout templates repo ⬇️  
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #@v6.0.2
         with:
           ref: ${{env.TEMPLATE_REF}}
           repository: ${{env.TEMPLATE_REPO}}


### PR DESCRIPTION
Node20 reached EOL. Update outdated images with recent versions.

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/